### PR TITLE
making component preview background white

### DIFF
--- a/styles/componentPreview.module.css
+++ b/styles/componentPreview.module.css
@@ -1,7 +1,7 @@
 .container {
   height: 100vh;
   width: 100%;
-  background: black;
+  background: white;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -12,7 +12,6 @@
   right: 0;
   text-align: center;
   position: absolute;
-  color: white;
   font-size: 2rem;
   padding-left: 14px;
   padding-right: 14px;


### PR DESCRIPTION
The component preview page has a black background, which makes it hard to develop components with white background as you have to manually specify a color.

| Before | After |
| -- | -- |
| <img width="866" alt="Screenshot 2023-07-14 at 6 22 11 PM" src="https://github.com/ConnectOrlando/connectorlandoweb/assets/10868575/c010da37-1430-4186-91cd-e81b0b2ea123"> | <img width="822" alt="Screenshot 2023-07-14 at 6 15 52 PM" src="https://github.com/ConnectOrlando/connectorlandoweb/assets/10868575/73a39fe2-0f3f-48c1-81ff-e07023913f76"> |